### PR TITLE
otasigcheck: Extract the key

### DIFF
--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -150,6 +150,7 @@ class EdifyGenerator(object):
     self.script.append(('run_program("/tmp/install/bin/backuptool.sh", "%s");' % command))
 
   def ValidateSignatures(self, command):
+    self.script.append('package_extract_file("META-INF/org/cyanogenmod/releasekey", "/tmp/releasekey");')
     # Exit code 124 == abort. run_program returns raw, so left-shift 8bit
     self.script.append('run_program("/tmp/install/bin/otasigcheck.sh") != "31744" || abort("Can\'t install this package on top of incompatible data. Please try another package or run a factory reset");')
 


### PR DESCRIPTION
* commit b110c751b181423d268531c624db212d2d81e816
  "build: ota: Support for install tools in /tmp/install"
  erroneously removed the line extracting the releasekey,
  making the script a no-op as it couldn't find a key to
  compare against.

Change-Id: I0dc5d15dbf4b0531de4df9e62a5bd47ec463c2a1