### PR TITLE
minnow_max: search for cm.mk in additional directories

### DIFF
--- a/core/product_config.mk
+++ b/core/product_config.mk
@@ -181,7 +181,7 @@ include $(BUILD_SYSTEM)/device.mk
 
 # A CM build needs only the CM product makefiles.
 ifneq ($(CM_BUILD),)
-  all_product_configs := $(shell ls device/*/$(CM_BUILD)/cm.mk)
+  all_product_configs := $(shell find device -path "*/$(CM_BUILD)/cm.mk")
 else
   ifneq ($(strip $(TARGET_BUILD_APPS)),)
   # An unbundled app build needs only the core product makefiles.


### PR DESCRIPTION
Intel's product configuration files are structured slightly
differentily than others.  Device-specific configuration is nested
one additional level, as follows:

device/intel/<family>/<product>/

Change-Id: I78b02978dc759b94024e5c5533d1108ac2634549